### PR TITLE
Fix log json

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,8 +285,11 @@ async function handleGetLog (res, redis) {
     if (batch.length === 0) {
       break
     }
-    offset += batchSize
+    if (offset !== 0) {
+      res.write(',')
+    }
     res.write(batch.join(','))
+    offset += batchSize
   }
 
   res.end(']')


### PR DESCRIPTION
Silly mistake. Would be nice to add tests where we have more than `batchSize` log entries